### PR TITLE
Bug: fixes plot not updating on some systems

### DIFF
--- a/pyXspecCorner.py
+++ b/pyXspecCorner.py
@@ -1,7 +1,7 @@
 import argparse
 import numpy as np
 import pandas as pd
-import arviz
+# import arviz
 import matplotlib.pyplot as plt
 from matplotlib.widgets import CheckButtons, TextBox
 from astropy.io import fits
@@ -33,7 +33,8 @@ def UpdateCornerPlot(selectedTitles, contours, showTitles, showXYlabels, selecte
                   plot_datapoints=False, plot_density=True, plot_contours=contours, smooth=True,
                   quantiles=(0.16, 0.84), use_math_text=True, bins=bins, labelpad=labelpad)
 
-    figcorner.canvas.draw()
+    figcorner.canvas.draw_idle()
+    figbuttons.canvas.draw_idle()
     return
 
 
@@ -180,5 +181,4 @@ if __name__ == '__main__':
             chTextBoxes.append(text_box)
 
     UpdateCornerPlot(selectedTitles, contours, showTitles, showXYlabels, selectedAltNames)
-
     plt.show()

--- a/pyXspecCorner.py
+++ b/pyXspecCorner.py
@@ -1,7 +1,7 @@
 import argparse
 import numpy as np
 import pandas as pd
-# import arviz
+import arviz
 import matplotlib.pyplot as plt
 from matplotlib.widgets import CheckButtons, TextBox
 from astropy.io import fits


### PR DESCRIPTION
Was not updating plots on my MacOS system.
System Version: macOS 11.6.6 (20G624)
Kernel Version: Darwin 20.6.0

I'm also running latest version of all libraries used (matplotlib, corne
r, etc.). So bug could have been caused by either of these.

Fixed by changing draw() to draw_idle() and adding draw_idle() for
the figbuttons object